### PR TITLE
BUGFIX: shutdown not cleaning up PID file

### DIFF
--- a/pkg/usr/bin/dhis2-shutdown
+++ b/pkg/usr/bin/dhis2-shutdown
@@ -13,6 +13,7 @@ if [ "$#" -ne 1 ]; then
 fi
 
 INSTANCE=$1
+PID_FILE=/var/lib/dhis2/$INSTANCE/tomcat.pid
 PID=$(cat /var/lib/dhis2/$INSTANCE/tomcat.pid)
 echo "Shutting down dhis2 instance"
-sudo -u $INSTANCE kill $PID || sudo -u $INSTANCE rm $PID 
+sudo -u $INSTANCE kill $PID && sudo -u $INSTANCE rm $PID_FILE 


### PR DESCRIPTION
Script was generating the name of the file to be deleted wrongly and inverted the test for shell exit codes